### PR TITLE
Allow empty list of sinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,12 @@ sink. Intended to use as bound to hotkey cmd.
 Usage:
 ======
 
-`pa-switch-sink -sinks jack,rtp`
+`pa-switch-sink [-sinks jack,rtp]`
 
-Program will find current default sink and chose next one in list.
+Program will find current default sink and chose next one in the list. If the
+list of sinks is empty, pa-switch-sink will go through all available sinks.
 
-`pa-switch-sink -sinks jack,rtp -last-only`
+`pa-switch-sink [-sinks jack,rtp] -last-only`
 
 When `-last-only` flag is set only default sink and last active stream will be
 switched to another sink.
-


### PR DESCRIPTION
Now pa-switch-sink just switches available sinks if no list has given.

Much easier if you are lazy enough and have 3+ devices to switch.