### PR TITLE
fix switching: skip failed stream

### DIFF
--- a/main.go
+++ b/main.go
@@ -140,7 +140,7 @@ func doSwitch(client *pulseaudio.Client, sinks []string, lastOnly bool) error {
 		dev := client.Stream(stream)
 		err = dev.Call("org.PulseAudio.Core1.Stream.Move", 0, targetPath).Err
 		if err != nil {
-			return fmt.Errorf("failed to switch stream '%s' to target '%v': %v", stream, targetSink, err)
+			log.Printf("failed to switch stream '%s' to target '%v': %v", stream, targetSink, err)
 		}
 	}
 


### PR DESCRIPTION
Sometimes for whatever reason there is a problem with switching sink for
telegram-desktop, pulseaudio's error doesn't really tell about the cause:
```
2019/11/03 21:07:57 failed to switch stream '/org/pulseaudio/core1/playback_stream10' to target 'alsa_output.usb-FiiO_DigiHug_USB_Audio-01.analog-stereo': Moving playback stream 10 to sink alsa_output.usb-FiiO_DigiHug_USB_Audio-01.analog-stereo failed.
```

But pa-switch-sink was stopping switching other stream when got a first error
although other sinks could be switched (like music player and browser stream).